### PR TITLE
Exhibition Entity and relationship with Museum Entity

### DIFF
--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Exhibition.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Exhibition.java
@@ -4,10 +4,8 @@ import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity(name = "Exhibition")
@@ -18,8 +16,9 @@ public class Exhibition {
 	@GeneratedValue(generator = "UUID")
 	private UUID id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	private Museum museum;
+//	@ManyToOne(fetch = FetchType.LAZY)
+//	private Museum museum;
+//	
 	
 	@Column(name = "Exhibition_Name", unique=true)
 	private String name;
@@ -30,10 +29,11 @@ public class Exhibition {
 	@Column(name = "Booked_seats")
 	private int bookedSeats;
 	
+	@Column(name = "Museum_id")
+	UUID museumId;
+	
 
-	public Exhibition(Museum museum, String name, int totalSeats) {
-		super();
-		this.museum = museum;
+	public Exhibition(String name, int totalSeats) {
 		this.name = name;
 		this.totalSeats = totalSeats;
 	}
@@ -44,14 +44,6 @@ public class Exhibition {
 
 	public void setId(UUID id) {
 		this.id = id;
-	}
-
-	public Museum getMuseum() {
-		return museum;
-	}
-
-	public void setMuseum(Museum museum) {
-		this.museum = museum;
 	}
 
 	public String getName() {
@@ -77,14 +69,22 @@ public class Exhibition {
 	public void setBookedSeats(int bookedSeats) {
 		this.bookedSeats = bookedSeats;
 	}
-	
+
+	public UUID getMuseumId() {
+		return museumId;
+	}
+
+	public void setMuseumId(UUID museumId) {
+		this.museumId = museumId;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + bookedSeats;
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result + ((museum == null) ? 0 : museum.hashCode());
+		result = prime * result + ((museumId == null) ? 0 : museumId.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		result = prime * result + totalSeats;
 		return result;
@@ -106,10 +106,10 @@ public class Exhibition {
 				return false;
 		} else if (!id.equals(other.id))
 			return false;
-		if (museum == null) {
-			if (other.museum != null)
+		if (museumId == null) {
+			if (other.museumId != null)
 				return false;
-		} else if (!museum.equals(other.museum))
+		} else if (!museumId.equals(other.museumId))
 			return false;
 		if (name == null) {
 			if (other.name != null)
@@ -120,5 +120,7 @@ public class Exhibition {
 			return false;
 		return true;
 	}
+	
+	
 
 }

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Exhibition.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Exhibition.java
@@ -1,0 +1,124 @@
+package com.unifi.attws.exam.model;
+
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity(name = "Exhibition")
+@Table(name = "exhibitions")
+public class Exhibition {
+	
+	@Id
+	@GeneratedValue(generator = "UUID")
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Museum museum;
+	
+	@Column(name = "Exhibition_Name", unique=true)
+	private String name;
+	
+	@Column(name = "Total_seats")
+	private int totalSeats;
+	
+	@Column(name = "Booked_seats")
+	private int bookedSeats;
+	
+
+	public Exhibition(Museum museum, String name, int totalSeats) {
+		super();
+		this.museum = museum;
+		this.name = name;
+		this.totalSeats = totalSeats;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public Museum getMuseum() {
+		return museum;
+	}
+
+	public void setMuseum(Museum museum) {
+		this.museum = museum;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getTotalSeats() {
+		return totalSeats;
+	}
+
+	public void setTotalSeats(int totalSeats) {
+		this.totalSeats = totalSeats;
+	}
+
+	public int getBookedSeats() {
+		return bookedSeats;
+	}
+
+	public void setBookedSeats(int bookedSeats) {
+		this.bookedSeats = bookedSeats;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + bookedSeats;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((museum == null) ? 0 : museum.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + totalSeats;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Exhibition other = (Exhibition) obj;
+		if (bookedSeats != other.bookedSeats)
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (museum == null) {
+			if (other.museum != null)
+				return false;
+		} else if (!museum.equals(other.museum))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (totalSeats != other.totalSeats)
+			return false;
+		return true;
+	}
+
+}

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Exhibition.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Exhibition.java
@@ -15,10 +15,6 @@ public class Exhibition {
 	@Id
 	@GeneratedValue(generator = "UUID")
 	private UUID id;
-
-//	@ManyToOne(fetch = FetchType.LAZY)
-//	private Museum museum;
-//	
 	
 	@Column(name = "Exhibition_Name", unique=true)
 	private String name;
@@ -36,6 +32,10 @@ public class Exhibition {
 	public Exhibition(String name, int totalSeats) {
 		this.name = name;
 		this.totalSeats = totalSeats;
+	}
+	
+	public Exhibition() {
+		
 	}
 
 	public UUID getId() {

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Museum.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Museum.java
@@ -1,11 +1,15 @@
 package com.unifi.attws.exam.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 @Entity(name = "Museum")
@@ -24,11 +28,15 @@ public final class Museum {
 
 	@Column(name = "Number_Of_Occupied_Rooms")
 	private int occupiedRooms;
+	
+	@OneToMany(cascade = CascadeType.ALL, mappedBy = "museum", orphanRemoval = true)
+	private List<Exhibition> exhibitions;
 
 	public Museum(String name, int rooms) {
 		this.name = name;
 		this.rooms = rooms;
 		this.occupiedRooms = 0;
+		this.exhibitions = new ArrayList<Exhibition>();
 
 	}
 
@@ -67,11 +75,22 @@ public final class Museum {
 	public void setOccupiedRooms(int availableRooms) {
 		this.occupiedRooms = availableRooms;
 	}
+	
+	
+
+	public List<Exhibition> getExhibitions() {
+		return exhibitions;
+	}
+
+	public void setExhibitions(List<Exhibition> exhibitions) {
+		this.exhibitions = exhibitions;
+	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((exhibitions == null) ? 0 : exhibitions.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		result = prime * result + occupiedRooms;
@@ -88,6 +107,11 @@ public final class Museum {
 		if (getClass() != obj.getClass())
 			return false;
 		Museum other = (Museum) obj;
+		if (exhibitions == null) {
+			if (other.exhibitions != null)
+				return false;
+		} else if (!exhibitions.equals(other.exhibitions))
+			return false;
 		if (id == null) {
 			if (other.id != null)
 				return false;
@@ -104,6 +128,7 @@ public final class Museum {
 			return false;
 		return true;
 	}
+
 	
 	
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Museum.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Museum.java
@@ -25,14 +25,11 @@ public final class Museum{
 	@Column(name = "Number_Of_Occupied_Rooms")
 	private int occupiedRooms;
 	
-//	@OneToMany(cascade = CascadeType.ALL, mappedBy = "museum", orphanRemoval = true)
-//	private List<Exhibition> exhibitions;
 
 	public Museum(String name, int rooms) {
 		this.name = name;
 		this.rooms = rooms;
 		this.occupiedRooms = 0;
-//		this.exhibitions = new ArrayList<Exhibition>();
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Museum.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/model/Museum.java
@@ -1,20 +1,16 @@
 package com.unifi.attws.exam.model;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 @Entity(name = "Museum")
 @Table(name = "museums")
-public final class Museum {
+public final class Museum{
 	
 	@Id
 	@GeneratedValue(generator = "UUID")
@@ -29,14 +25,14 @@ public final class Museum {
 	@Column(name = "Number_Of_Occupied_Rooms")
 	private int occupiedRooms;
 	
-	@OneToMany(cascade = CascadeType.ALL, mappedBy = "museum", orphanRemoval = true)
-	private List<Exhibition> exhibitions;
+//	@OneToMany(cascade = CascadeType.ALL, mappedBy = "museum", orphanRemoval = true)
+//	private List<Exhibition> exhibitions;
 
 	public Museum(String name, int rooms) {
 		this.name = name;
 		this.rooms = rooms;
 		this.occupiedRooms = 0;
-		this.exhibitions = new ArrayList<Exhibition>();
+//		this.exhibitions = new ArrayList<Exhibition>();
 
 	}
 
@@ -75,22 +71,11 @@ public final class Museum {
 	public void setOccupiedRooms(int availableRooms) {
 		this.occupiedRooms = availableRooms;
 	}
-	
-	
-
-	public List<Exhibition> getExhibitions() {
-		return exhibitions;
-	}
-
-	public void setExhibitions(List<Exhibition> exhibitions) {
-		this.exhibitions = exhibitions;
-	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((exhibitions == null) ? 0 : exhibitions.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		result = prime * result + occupiedRooms;
@@ -107,11 +92,6 @@ public final class Museum {
 		if (getClass() != obj.getClass())
 			return false;
 		Museum other = (Museum) obj;
-		if (exhibitions == null) {
-			if (other.exhibitions != null)
-				return false;
-		} else if (!exhibitions.equals(other.exhibitions))
-			return false;
 		if (id == null) {
 			if (other.id != null)
 				return false;
@@ -128,8 +108,18 @@ public final class Museum {
 			return false;
 		return true;
 	}
+	
+	
 
+//	public List<Exhibition> getExhibitions() {
+//		return exhibitions;
+//	}
+//
+//	public void setExhibitions(List<Exhibition> exhibitions) {
+//		this.exhibitions = exhibitions;
+//	}
 	
 	
+
 
 }

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
@@ -1,0 +1,16 @@
+package com.unifi.attws.exam.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.unifi.attws.exam.model.Exhibition;;
+
+public interface ExhibitionRepository {
+	public List<Exhibition> findAllExhibition();
+	public List<Exhibition> findExhibitionsByMuseum(UUID museumId);
+	public Exhibition findExhibitionById(UUID exhibitionId);
+	public void addNewExhibition(Exhibition newExhibition);
+	public void updateExhibition(Exhibition updatedExhibition);
+	public void deleteExhibition(Exhibition deletedExhibition);
+	
+}

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
@@ -9,7 +9,7 @@ public interface ExhibitionRepository {
 	public List<Exhibition> findAllExhibitions();
 	public Exhibition findExhibitionById(UUID exhibitionId);
 	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId);
-	public void addNewExhibition(Exhibition newExhibition);
+	public Exhibition addNewExhibition(Exhibition newExhibition);
 	public void updateExhibition(Exhibition updatedExhibition);
 	public void deleteExhibition(Exhibition deletedExhibition);
 	

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
@@ -7,8 +7,8 @@ import com.unifi.attws.exam.model.Exhibition;;
 
 public interface ExhibitionRepository {
 	public List<Exhibition> findAllExhibitions();
-	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId);
 	public Exhibition findExhibitionById(UUID exhibitionId);
+	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId);
 	public void addNewExhibition(Exhibition newExhibition);
 	public void updateExhibition(Exhibition updatedExhibition);
 	public void deleteExhibition(Exhibition deletedExhibition);

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 import com.unifi.attws.exam.model.Exhibition;;
 
 public interface ExhibitionRepository {
-	public List<Exhibition> findAllExhibition();
-	public List<Exhibition> findExhibitionsByMuseum(UUID museumId);
+	public List<Exhibition> findAllExhibitions();
+	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId);
 	public Exhibition findExhibitionById(UUID exhibitionId);
 	public void addNewExhibition(Exhibition newExhibition);
 	public void updateExhibition(Exhibition updatedExhibition);

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/ExhibitionRepository.java
@@ -10,7 +10,7 @@ public interface ExhibitionRepository {
 	public Exhibition findExhibitionById(UUID exhibitionId);
 	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId);
 	public Exhibition addNewExhibition(Exhibition newExhibition);
-	public void updateExhibition(Exhibition updatedExhibition);
+	public Exhibition updateExhibition(Exhibition updatedExhibition);
 	public void deleteExhibition(Exhibition deletedExhibition);
 	
 }

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/MuseumRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/MuseumRepository.java
@@ -10,7 +10,7 @@ public interface MuseumRepository {
 	public List<Museum> findAllMuseums();
 	public Museum retrieveMuseumById(UUID id);
 	public Museum addMuseum(Museum museum);
-	public void updateMuseum(Museum updatedMuseum);
+	public Museum updateMuseum(Museum updatedMuseum);
 	public void deleteMuseum(Museum museumToRemove);
 	
 }

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
@@ -1,0 +1,64 @@
+package com.unifi.attws.exam.repository.postgres;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+
+import com.unifi.attws.exam.model.Exhibition;
+import com.unifi.attws.exam.repository.ExhibitionRepository;
+
+public class PostgresExhibitionRepository implements ExhibitionRepository{
+	
+	private EntityManager entityManager;
+
+
+	@Override
+	public List<Exhibition> findAllExhibition() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<Exhibition> findExhibitionsByMuseum(UUID museumId) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Exhibition findExhibitionById(UUID exhibitionId) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void addNewExhibition(Exhibition newExhibition) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void updateExhibition(Exhibition updatedExhibition) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void deleteExhibition(Exhibition deletedExhibition) {
+		// TODO Auto-generated method stub
+		
+	}
+	
+	public PostgresExhibitionRepository(EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+	
+	public EntityManager getEntityManager() {
+		return entityManager;
+	}
+	
+	public void setEntityManager(EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+
+}

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
@@ -18,11 +18,15 @@ public class PostgresExhibitionRepository implements ExhibitionRepository {
 		List<Exhibition> exhibitions = entityManager.createQuery("FROM Exhibition", Exhibition.class).getResultList();
 		return exhibitions;
 	}
-	
+
 	@Override
 	public Exhibition findExhibitionById(UUID exhibitionId) {
+		try {
 			return entityManager.find(Exhibition.class, exhibitionId);
-		
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
+
 	}
 
 	@Override
@@ -31,29 +35,38 @@ public class PostgresExhibitionRepository implements ExhibitionRepository {
 			throw new IllegalArgumentException("Museum ID cannot be null.");
 		}
 
-		return findAllExhibitions()
-				.stream()
-				.filter(e -> e.getMuseumId().equals(museumId))
-				.collect(Collectors.toList());
+		return findAllExhibitions().stream().filter(e -> e.getMuseumId().equals(museumId)).collect(Collectors.toList());
 
 	}
 
 	@Override
 	public Exhibition addNewExhibition(Exhibition newExhibition) {
-		entityManager.persist(newExhibition);
-		return newExhibition;
+		try {
+			entityManager.persist(newExhibition);
+			return newExhibition;
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 
 	}
 
 	@Override
-	public void updateExhibition(Exhibition updatedExhibition) {
-		// TODO Auto-generated method stub
+	public Exhibition updateExhibition(Exhibition updatedExhibition) {
+		try {
+			return entityManager.merge(updatedExhibition);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 
 	}
 
 	@Override
 	public void deleteExhibition(Exhibition deletedExhibition) {
-		// TODO Auto-generated method stub
+		try {
+			entityManager.remove(deletedExhibition);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
@@ -22,7 +22,6 @@ public class PostgresExhibitionRepository implements ExhibitionRepository {
 	@Override
 	public Exhibition findExhibitionById(UUID exhibitionId) {
 			return entityManager.find(Exhibition.class, exhibitionId);
-
 		
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
@@ -40,8 +40,9 @@ public class PostgresExhibitionRepository implements ExhibitionRepository {
 	}
 
 	@Override
-	public void addNewExhibition(Exhibition newExhibition) {
-		// TODO Auto-generated method stub
+	public Exhibition addNewExhibition(Exhibition newExhibition) {
+		entityManager.persist(newExhibition);
+		return newExhibition;
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
@@ -18,29 +18,24 @@ public class PostgresExhibitionRepository implements ExhibitionRepository {
 		List<Exhibition> exhibitions = entityManager.createQuery("FROM Exhibition", Exhibition.class).getResultList();
 		return exhibitions;
 	}
+	
+	@Override
+	public Exhibition findExhibitionById(UUID exhibitionId) {
+			return entityManager.find(Exhibition.class, exhibitionId);
+
+		
+	}
 
 	@Override
 	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId) {
 		if (museumId == null) {
 			throw new IllegalArgumentException("Museum ID cannot be null.");
 		}
-		try {
-			return findAllExhibitions().stream()
-					.filter(e -> e.getMuseumId().equals(museumId))
-					.collect(Collectors.toList());
 
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException();
-		}
-	}
-
-	@Override
-	public Exhibition findExhibitionById(UUID exhibitionId) {
-		try {
-			return entityManager.find(Exhibition.class, exhibitionId);
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException();
-		}
+		return findAllExhibitions()
+				.stream()
+				.filter(e -> e.getMuseumId().equals(museumId))
+				.collect(Collectors.toList());
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresExhibitionRepository.java
@@ -2,61 +2,74 @@ package com.unifi.attws.exam.repository.postgres;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 
 import com.unifi.attws.exam.model.Exhibition;
 import com.unifi.attws.exam.repository.ExhibitionRepository;
 
-public class PostgresExhibitionRepository implements ExhibitionRepository{
-	
+public class PostgresExhibitionRepository implements ExhibitionRepository {
+
 	private EntityManager entityManager;
 
-
 	@Override
-	public List<Exhibition> findAllExhibition() {
-		// TODO Auto-generated method stub
-		return null;
+	public List<Exhibition> findAllExhibitions() {
+		List<Exhibition> exhibitions = entityManager.createQuery("FROM Exhibition", Exhibition.class).getResultList();
+		return exhibitions;
 	}
 
 	@Override
-	public List<Exhibition> findExhibitionsByMuseum(UUID museumId) {
-		// TODO Auto-generated method stub
-		return null;
+	public List<Exhibition> findExhibitionsByMuseumId(UUID museumId) {
+		if (museumId == null) {
+			throw new IllegalArgumentException("Museum ID cannot be null.");
+		}
+		try {
+			return findAllExhibitions().stream()
+					.filter(e -> e.getMuseumId().equals(museumId))
+					.collect(Collectors.toList());
+
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 	}
 
 	@Override
 	public Exhibition findExhibitionById(UUID exhibitionId) {
-		// TODO Auto-generated method stub
-		return null;
+		try {
+			return entityManager.find(Exhibition.class, exhibitionId);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
+
 	}
 
 	@Override
 	public void addNewExhibition(Exhibition newExhibition) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
 	public void updateExhibition(Exhibition updatedExhibition) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
 	public void deleteExhibition(Exhibition deletedExhibition) {
 		// TODO Auto-generated method stub
-		
+
 	}
-	
+
 	public PostgresExhibitionRepository(EntityManager entityManager) {
 		this.entityManager = entityManager;
 	}
-	
+
 	public EntityManager getEntityManager() {
 		return entityManager;
 	}
-	
+
 	public void setEntityManager(EntityManager entityManager) {
 		this.entityManager = entityManager;
 	}

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresMuseumRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresMuseumRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceException;
 
 import com.unifi.attws.exam.model.Museum;
 import com.unifi.attws.exam.repository.MuseumRepository;
@@ -26,40 +25,25 @@ public class PostgresMuseumRepository implements MuseumRepository {
 
 	@Override
 	public Museum retrieveMuseumById(UUID id) {
-		try {
 			return entityManager.find(Museum.class, id);
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException();
-		}
 	}
 
 	@Override
 	public Museum addMuseum(Museum museum) {
-		try {
 			entityManager.persist(museum);
-		} catch (PersistenceException ex) {
-			throw new PersistenceException();
-		}
 		return museum;
 
 	}
 
 	@Override
 	public void updateMuseum(Museum updatedMuseum) {
-		try {
 			entityManager.merge(updatedMuseum);
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException();
-		}
 	}
+
 
 	@Override
 	public void deleteMuseum(Museum museumToRemove) {
-		try {
 			entityManager.remove(museumToRemove);
-		} catch (PersistenceException ex) {
-			throw new PersistenceException();
-		}
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresMuseumRepository.java
+++ b/com.unifi.attws.exam.museum-app/src/main/java/com/unifi/attws/exam/repository/postgres/PostgresMuseumRepository.java
@@ -25,25 +25,40 @@ public class PostgresMuseumRepository implements MuseumRepository {
 
 	@Override
 	public Museum retrieveMuseumById(UUID id) {
+		try {
 			return entityManager.find(Museum.class, id);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 	}
 
 	@Override
 	public Museum addMuseum(Museum museum) {
+		try {
 			entityManager.persist(museum);
-		return museum;
+			return museum;
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 
 	}
 
 	@Override
-	public void updateMuseum(Museum updatedMuseum) {
-			entityManager.merge(updatedMuseum);
+	public Museum updateMuseum(Museum updatedMuseum) {
+		try {
+			return entityManager.merge(updatedMuseum);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 	}
-
 
 	@Override
 	public void deleteMuseum(Museum museumToRemove) {
+		try {
 			entityManager.remove(museumToRemove);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException();
+		}
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.unifi.attws.exam.test.repository.postgres;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.unifi.attws.exam.repository.postgres.PostgresExhibitionRepository;
+
+public class ExhibitionPostgresRepositoryTest {
+
+	private PostgresExhibitionRepository postgresExhibitionRepository;
+	private static EntityManager entityManager;
+
+	@Before
+	public void setUp() {
+		EntityManagerFactory sessionFactory = Persistence.createEntityManagerFactory("postgres");
+		entityManager = sessionFactory.createEntityManager();
+		postgresExhibitionRepository = new PostgresExhibitionRepository(entityManager);
+		entityManager.getTransaction().begin();
+
+	}
+
+	@Test
+	public void testFindAllExhibitionWhenNoExhibitionsArePersisted() {
+		assertThat(postgresExhibitionRepository.findAllExhibitions()).isEmpty();
+	}
+
+	@Test
+	public void testFindExhibitionByIdWhenNoExhibitionsArePersisted() {
+		assertThat(postgresExhibitionRepository.findExhibitionById(UUID.randomUUID())).isNull();
+	}
+
+	@Test
+	public void testFindExhibitionByIdWhenIdIsNullShouldThrow() {
+		assertThatThrownBy(() -> postgresExhibitionRepository.findExhibitionById(null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@After
+	public void closeEntityManager() {
+		entityManager.getTransaction().commit();
+		entityManager.clear();
+		entityManager.close();
+	}
+
+}

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
@@ -12,7 +12,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.unifi.attws.exam.model.Exhibition;
 import com.unifi.attws.exam.repository.ExhibitionRepository;
 import com.unifi.attws.exam.repository.postgres.PostgresExhibitionRepository;
 
@@ -55,17 +54,6 @@ public class ExhibitionPostgresRepositoryTest {
 		
 	}
 	
-	@Test
-	public void testAddNewExhibition() {
-		Exhibition exhibition = new Exhibition("test exhibition", 100);
-		 postgresExhibitionRepository.addNewExhibition(exhibition);
-		 
-		 assertThat(postgresExhibitionRepository.findAllExhibitions())
-		 	.hasSize(1)
-		 	.extracting(Exhibition::getId)
-		 	.contains(exhibition.getId());
-	}
-
 	@After
 	public void closeEntityManager() {
 		entityManager.getTransaction().commit();

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
@@ -56,7 +56,7 @@ public class ExhibitionPostgresRepositoryTest {
 	
 	@After
 	public void closeEntityManager() {
-		entityManager.getTransaction().commit();
+		entityManager.getTransaction().rollback();
 		entityManager.clear();
 		entityManager.close();
 	}

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryTest.java
@@ -12,11 +12,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.unifi.attws.exam.model.Exhibition;
+import com.unifi.attws.exam.repository.ExhibitionRepository;
 import com.unifi.attws.exam.repository.postgres.PostgresExhibitionRepository;
 
 public class ExhibitionPostgresRepositoryTest {
 
-	private PostgresExhibitionRepository postgresExhibitionRepository;
+	private ExhibitionRepository postgresExhibitionRepository;
 	private static EntityManager entityManager;
 
 	@Before
@@ -42,6 +44,26 @@ public class ExhibitionPostgresRepositoryTest {
 	public void testFindExhibitionByIdWhenIdIsNullShouldThrow() {
 		assertThatThrownBy(() -> postgresExhibitionRepository.findExhibitionById(null))
 				.isInstanceOf(IllegalArgumentException.class);
+	}
+	
+	@Test
+	public void testAddNewNullExhibitionEntityShouldThrow() {
+		assertThatThrownBy(() -> postgresExhibitionRepository.addNewExhibition(null))
+		.isInstanceOf(IllegalArgumentException.class);
+		
+		assertThat(postgresExhibitionRepository.findAllExhibitions()).isEmpty();
+		
+	}
+	
+	@Test
+	public void testAddNewExhibition() {
+		Exhibition exhibition = new Exhibition("test exhibition", 100);
+		 postgresExhibitionRepository.addNewExhibition(exhibition);
+		 
+		 assertThat(postgresExhibitionRepository.findAllExhibitions())
+		 	.hasSize(1)
+		 	.extracting(Exhibition::getId)
+		 	.contains(exhibition.getId());
 	}
 
 	@After

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -31,6 +31,13 @@ public class ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest {
 		postgresExhibitionRepository = new PostgresExhibitionRepository(entityManager);
 		
 	}
+	
+	// Check if the sql script has been executed.
+	@Test
+	public void testfindAllMuseumsMuseumsWhenNoMuseumsArePersisted() {
+		assertThat(postgresExhibitionRepository.findAllExhibitions()).isNotEmpty();
+
+	}
 
 	@Test
 	public void testFindAllExhibitionsWhenSeveralExhibitionsArePersisted() {

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -29,6 +29,7 @@ public class ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest {
 		EntityManagerFactory sessionFactory = Persistence.createEntityManagerFactory("postgres.not-empty.database");
 		entityManager = sessionFactory.createEntityManager();
 		postgresExhibitionRepository = new PostgresExhibitionRepository(entityManager);
+		
 	}
 
 	@Test

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -79,7 +79,7 @@ public class ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest {
 	}
 
 	@Test
-	public void testAddNewExhibitionWhenArelatedMuseumIdExists() {
+	public void testAddNewExhibitionWhenRelatedMuseumIdExists() {
 		Exhibition exhibition = new Exhibition("test exhibition", 100);
 		exhibition.setMuseumId(UUID.fromString(MUSEUM_1));
 		postgresExhibitionRepository.addNewExhibition(exhibition);
@@ -89,10 +89,52 @@ public class ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest {
 				.contains(exhibition.getId());
 	}
 
+	@Test
+	public void testUpdateExhibitionWithNullEntityShouldThrow() {
+		assertThatThrownBy(() -> postgresExhibitionRepository.updateExhibition(null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+	}
+
+	@Test
+	public void testUpdateExhibition() {
+		Exhibition exhibition1 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_1));
+		exhibition1.setBookedSeats(10);
+		postgresExhibitionRepository.updateExhibition(exhibition1);
+
+		assertThat(postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_1)).getBookedSeats())
+				.isEqualTo(10);
+
+	}
+
+	@Test
+	public void testUpdateExhibitionWithDetachedEntityShouldThrow() {
+		Exhibition exhibition1 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_1));
+		exhibition1.setId(UUID.randomUUID());
+
+		assertThatThrownBy(() -> postgresExhibitionRepository.updateExhibition(null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+	}
+
+	@Test
+	public void testRemoveNullExhibitionShouldThrow() {
+		assertThatThrownBy(() -> postgresExhibitionRepository.deleteExhibition(null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+	
+	@Test
+	public void testRemoveExhibition() {
+		Exhibition exhibition1 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_1));
+		Exhibition exhibition2 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_2));
+		postgresExhibitionRepository.deleteExhibition(exhibition1);
+		
+		assertThat(postgresExhibitionRepository.findAllExhibitions()).containsExactly(exhibition2);
+	}
 
 	@After
 	public void closeEntityManager() {
-		entityManager.getTransaction().commit();
+		entityManager.getTransaction().rollback();
 		entityManager.clear();
 		entityManager.close();
 	}

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -1,0 +1,72 @@
+package com.unifi.attws.exam.test.repository.postgres;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.unifi.attws.exam.model.Exhibition;
+import com.unifi.attws.exam.repository.ExhibitionRepository;
+import com.unifi.attws.exam.repository.postgres.PostgresExhibitionRepository;
+
+public class ExhibitionPostgresRepositoryWithNotEmptyDatabaseTest {
+
+	private static final String MUSEUM_1 = "b433da18-ba5a-4b86-92af-ba11be6314e7";
+	private static final String EXHIBITION_2 = "b2cb1474-24ff-41eb-a8d7-963f32f6822d";
+	private static final String EXHIBITION_1 = "49d13e51-2277-4911-929f-c9c067e2e8b4";
+
+	private ExhibitionRepository postgresExhibitionRepository;
+	private static EntityManager entityManager;
+
+	@Before
+	public void setUp() {
+		EntityManagerFactory sessionFactory = Persistence.createEntityManagerFactory("postgres.not-empty.database");
+		entityManager = sessionFactory.createEntityManager();
+		postgresExhibitionRepository = new PostgresExhibitionRepository(entityManager);
+	}
+
+	@Test
+	public void testFindAllExhibitionsWhenSeveralExhibitionsArePersisted() {
+		Exhibition exhibition1 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_1));
+		Exhibition exhibition2 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_2));
+
+		assertThat(postgresExhibitionRepository.findAllExhibitions()).containsExactly(exhibition1, exhibition2);
+	}
+
+	@Test
+	public void testFindExhibitionByIdWhenSeveralExhibitionsArePersistedButIdDoesNotMatch() {
+
+		assertThat(postgresExhibitionRepository.findExhibitionById(UUID.randomUUID())).isNull();
+	}
+
+	@Test
+	public void testFindExhibitionsByMuseumIdWhenNoMuseumsArePersisted() {
+
+		assertThat(postgresExhibitionRepository.findExhibitionsByMuseumId(UUID.randomUUID())).isEmpty();
+	}
+
+	@Test
+	public void testFindExhibitionByMuseumIdWhenGivenIdIsNullShouldThrow() {
+		
+		assertThatThrownBy(() -> postgresExhibitionRepository.findExhibitionsByMuseumId(null))
+		.isInstanceOf(IllegalArgumentException.class)
+		.hasMessage("Museum ID cannot be null.");
+	}
+
+	@Test
+	public void testFindExhibitionsByMuseumIdWhenMuseumsArePersisted() {
+		Exhibition exhibition1 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_1));
+		Exhibition exhibition2 = postgresExhibitionRepository.findExhibitionById(UUID.fromString(EXHIBITION_2));
+
+		assertThat(postgresExhibitionRepository.findExhibitionsByMuseumId(UUID.fromString(MUSEUM_1)))
+				.containsExactly(exhibition1, exhibition2);
+
+	}
+
+}

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
@@ -35,7 +35,13 @@ public class MuseumPostgresRepositoryTest {
 		assertThat(postgresMuseumRepository.findAllMuseums()).isEmpty();
 
 	}
-
+	
+	@Test
+	public void testFindMuseumByNullIdShouldThrow() {
+		assertThatThrownBy(() -> postgresMuseumRepository.retrieveMuseumById(null))
+		.isInstanceOf(IllegalArgumentException.class);	
+	}
+	
 	@Test
 	public void testFindMuseumByIdWhenNoMuseumsArePresent() {
 		assertThat(postgresMuseumRepository.retrieveMuseumById(UUID.randomUUID())).isNull();
@@ -70,12 +76,6 @@ public class MuseumPostgresRepositoryTest {
 		assertThat(postgresMuseumRepository.retrieveMuseumById(museum1.getId())).isEqualTo(museum1);
 	}
 	
-	@Test
-	public void testFindMuseumByNullIdShouldThrow() {
-		assertThatThrownBy(() -> postgresMuseumRepository.retrieveMuseumById(null))
-		.isInstanceOf(IllegalArgumentException.class);
-		
-	}
 
 	@Test
 	public void testUpdateMuseumWhenExists() {

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
@@ -12,7 +12,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.unifi.attws.exam.model.Exhibition;
 import com.unifi.attws.exam.model.Museum;
 import com.unifi.attws.exam.repository.MuseumRepository;
 import com.unifi.attws.exam.repository.postgres.PostgresMuseumRepository;
@@ -45,8 +44,6 @@ public class MuseumPostgresRepositoryTest {
 	@Test
 	public void testAddNewMuseumToPostgresDBWhenTransactionSuccess() {
 		Museum museum = createTestMuseum("MoMa", 10);
-//		Exhibition ex = new Exhibition(museum, "Permanent exhibition", 100);
-//		museum.getExhibitions().add(ex);
 		postgresMuseumRepository.addMuseum(museum);
 		entityManager.flush();
 		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum);

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
@@ -40,14 +40,23 @@ public class MuseumPostgresRepositoryTest {
 	public void testFindMuseumByIdWhenNoMuseumsArePresent() {
 		assertThat(postgresMuseumRepository.retrieveMuseumById(UUID.randomUUID())).isNull();
 	}
+	
+	@Test
+	public void testAddNewNullMuseumEntityShouldThrow() {
+		assertThatThrownBy(() -> postgresMuseumRepository.addMuseum(null)).isInstanceOf(IllegalArgumentException.class);
+		
+		assertThat(postgresMuseumRepository.findAllMuseums()).isEmpty();
+	}
 
 	@Test
-	public void testAddNewMuseumToPostgresDBWhenTransactionSuccess() {
+	public void testAddNewMuseum() {
 		Museum museum = createTestMuseum("MoMa", 10);
 		postgresMuseumRepository.addMuseum(museum);
 		entityManager.flush();
-		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum);
-
+		assertThat(postgresMuseumRepository.findAllMuseums())
+		.hasSize(1)
+		.extracting(Museum::getId)
+		.contains(museum.getId());
 	}
 
 	@Test

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
@@ -59,16 +59,6 @@ public class MuseumPostgresRepositoryTest {
 		.contains(museum.getId());
 	}
 
-	@Test
-	public void testFindAllMuseumsWhenSeveralMuseumsArePersisted() {
-		Museum museum1 = createTestMuseum("Uffizi", 50);
-		Museum museum2 = createTestMuseum("Louvre", 10);
-		postgresMuseumRepository.addMuseum(museum1);
-		postgresMuseumRepository.addMuseum(museum2);
-		entityManager.flush();
-		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum1, museum2);
-
-	}
 
 	@Test
 	public void testFindMuseumByIdWhenMuseumIsPresent() {
@@ -100,14 +90,6 @@ public class MuseumPostgresRepositoryTest {
 
 	}
 
-	@Test
-	public void testRemoveMuseumWhenTheMuseumExists() {
-		Museum museum1 = createTestMuseum("Pompidou", 50);
-		postgresMuseumRepository.addMuseum(museum1);
-		postgresMuseumRepository.deleteMuseum(museum1);
-		entityManager.flush();
-		assertThat(postgresMuseumRepository.findAllMuseums()).isEmpty();
-	}
 	
 	@After
 	public void closeEntityManager() {

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.unifi.attws.exam.model.Exhibition;
 import com.unifi.attws.exam.model.Museum;
 import com.unifi.attws.exam.repository.MuseumRepository;
 import com.unifi.attws.exam.repository.postgres.PostgresMuseumRepository;
@@ -44,6 +45,8 @@ public class MuseumPostgresRepositoryTest {
 	@Test
 	public void testAddNewMuseumToPostgresDBWhenTransactionSuccess() {
 		Museum museum = createTestMuseum("MoMa", 10);
+//		Exhibition ex = new Exhibition(museum, "Permanent exhibition", 100);
+//		museum.getExhibitions().add(ex);
 		postgresMuseumRepository.addMuseum(museum);
 		entityManager.flush();
 		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum);

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -1,7 +1,6 @@
 package com.unifi.attws.exam.test.repository.postgres;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.UUID;
@@ -38,6 +37,14 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	@Test
 	public void testfindAllMuseumsMuseumsWhenNoMuseumsArePersisted() {
 		assertThat(postgresMuseumRepository.findAllMuseums()).isNotEmpty();
+
+	}
+	
+	@Test
+	public void testFindAllMuseumsWhenSeveralMuseumsArePersisted() {
+		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
+		Museum museum2 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString("94fe3013-9ebb-432e-ab55-e612dc797851"));
+		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum1, museum2);
 
 	}
 

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -20,6 +20,9 @@ import com.unifi.attws.exam.repository.postgres.PostgresMuseumRepository;
 
 public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 
+	private static final String MUSEUM_2 = "94fe3013-9ebb-432e-ab55-e612dc797851";
+	private static final String MUSEUM_1 = "b433da18-ba5a-4b86-92af-ba11be6314e7";
+	
 	private MuseumRepository postgresMuseumRepository;
 	private static EntityManager entityManager;
 	private List<Museum> persistedMuseums;
@@ -43,9 +46,9 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	@Test
 	public void testFindAllMuseumsWhenSeveralMuseumsArePersisted() {
 		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
+				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		Museum museum2 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString("94fe3013-9ebb-432e-ab55-e612dc797851"));
+				.retrieveMuseumById(UUID.fromString(MUSEUM_2));
 		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum1, museum2);
 
 	}
@@ -53,7 +56,7 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	@Test
 	public void testAddDetachedEntityMuseumShouldThrow() {
 		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
+				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		Museum museum2 = new Museum("test3", 20);
 		museum2.setId(museum1.getId());
 		assertThatThrownBy(() -> postgresMuseumRepository.addMuseum(museum2)).isInstanceOf(PersistenceException.class);
@@ -69,7 +72,7 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	@Test
 	public void testUpdateMuseumWhenEntityHasBeenRemovedShouldThrow() {
 		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
+				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		entityManager.remove(museum1);
 		museum1.setName("test_update");
 		assertThatThrownBy(() -> postgresMuseumRepository.updateMuseum(museum1))
@@ -87,7 +90,7 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	@Test
 	public void testRemoveDetachedEntityMuseumShouldThrow() {
 		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
+				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		Museum museum2 = new Museum("test3", 20);
 		museum2.setId(museum1.getId());
 

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -39,11 +39,13 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 		assertThat(postgresMuseumRepository.findAllMuseums()).isNotEmpty();
 
 	}
-	
+
 	@Test
 	public void testFindAllMuseumsWhenSeveralMuseumsArePersisted() {
-		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
-		Museum museum2 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString("94fe3013-9ebb-432e-ab55-e612dc797851"));
+		Museum museum1 = postgresMuseumRepository
+				.retrieveMuseumById(UUID.fromString("b433da18-ba5a-4b86-92af-ba11be6314e7"));
+		Museum museum2 = postgresMuseumRepository
+				.retrieveMuseumById(UUID.fromString("94fe3013-9ebb-432e-ab55-e612dc797851"));
 		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum1, museum2);
 
 	}
@@ -56,6 +58,12 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 		museum2.setId(museum1.getId());
 		assertThatThrownBy(() -> postgresMuseumRepository.addMuseum(museum2)).isInstanceOf(PersistenceException.class);
 		assertThat(postgresMuseumRepository.findAllMuseums()).isEqualTo(persistedMuseums);
+	}
+
+	@Test
+	public void testAddNullEntityShouldThrow() {
+		assertThatThrownBy(() -> postgresMuseumRepository.addMuseum(null)).isInstanceOf(IllegalArgumentException.class);
+		
 	}
 
 	@Test

--- a/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
+++ b/com.unifi.attws.exam.museum-app/src/test/java/com/unifi/attws/exam/test/repository/postgres/MuseumPostgresRepositoryWithNotEmptyDatabaseTest.java
@@ -22,7 +22,7 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 
 	private static final String MUSEUM_2 = "94fe3013-9ebb-432e-ab55-e612dc797851";
 	private static final String MUSEUM_1 = "b433da18-ba5a-4b86-92af-ba11be6314e7";
-	
+
 	private MuseumRepository postgresMuseumRepository;
 	private static EntityManager entityManager;
 	private List<Museum> persistedMuseums;
@@ -45,18 +45,15 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 
 	@Test
 	public void testFindAllMuseumsWhenSeveralMuseumsArePersisted() {
-		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
-		Museum museum2 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString(MUSEUM_2));
+		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString(MUSEUM_1));
+		Museum museum2 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString(MUSEUM_2));
 		assertThat(postgresMuseumRepository.findAllMuseums()).containsExactly(museum1, museum2);
 
 	}
 
 	@Test
 	public void testAddDetachedEntityMuseumShouldThrow() {
-		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
+		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		Museum museum2 = new Museum("test3", 20);
 		museum2.setId(museum1.getId());
 		assertThatThrownBy(() -> postgresMuseumRepository.addMuseum(museum2)).isInstanceOf(PersistenceException.class);
@@ -66,13 +63,12 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	@Test
 	public void testAddNullEntityShouldThrow() {
 		assertThatThrownBy(() -> postgresMuseumRepository.addMuseum(null)).isInstanceOf(IllegalArgumentException.class);
-		
+
 	}
 
 	@Test
 	public void testUpdateMuseumWhenEntityHasBeenRemovedShouldThrow() {
-		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
+		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		entityManager.remove(museum1);
 		museum1.setName("test_update");
 		assertThatThrownBy(() -> postgresMuseumRepository.updateMuseum(museum1))
@@ -89,8 +85,7 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 
 	@Test
 	public void testRemoveDetachedEntityMuseumShouldThrow() {
-		Museum museum1 = postgresMuseumRepository
-				.retrieveMuseumById(UUID.fromString(MUSEUM_1));
+		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString(MUSEUM_1));
 		Museum museum2 = new Museum("test3", 20);
 		museum2.setId(museum1.getId());
 
@@ -101,10 +96,18 @@ public class MuseumPostgresRepositoryWithNotEmptyDatabaseTest {
 	}
 
 	@Test
-	public void testRemoveNonEntityObjectShouldThrow() {
+	public void testRemoveNullEntityObjectShouldThrow() {
 		assertThatThrownBy(() -> postgresMuseumRepository.deleteMuseum(null))
 				.isInstanceOf(IllegalArgumentException.class);
 		assertThat(postgresMuseumRepository.findAllMuseums()).isEqualTo(persistedMuseums);
+	}
+
+	@Test
+	public void testRemoveMuseumWhenTheMuseumExistsAndHasNotExhibitions() {
+		Museum museum1 = postgresMuseumRepository.retrieveMuseumById(UUID.fromString(MUSEUM_2));
+		postgresMuseumRepository.deleteMuseum(museum1);
+		entityManager.flush();
+		assertThat(postgresMuseumRepository.findAllMuseums()).hasSize(1);
 	}
 
 	@After

--- a/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/init_postgresql.sql
+++ b/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/init_postgresql.sql
@@ -8,10 +8,9 @@ CREATE TABLE museums(
 
 );
 
-
 CREATE TABLE exhibitions(
    ID UUID  NOT NULL,
-   museum_id UUID NOT NULL,
+   museum_id UUID NOT NULL references museums(ID),
    exhibition_name TEXT NOT NULL,
    total_seats INT NOT NULL,
    booked_seats INT NOT NULL,

--- a/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/init_postgresql.sql
+++ b/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/init_postgresql.sql
@@ -25,3 +25,10 @@ VALUES ( 'b433da18-ba5a-4b86-92af-ba11be6314e7' , 'test1', 0, 10);
 
 INSERT INTO museums (id, museum_name, number_of_occupied_rooms, number_of_rooms)
 VALUES ( '94fe3013-9ebb-432e-ab55-e612dc797851' , 'test2', 0, 10);
+
+INSERT INTO exhibitions(id, museum_id, exhibition_name, total_seats, booked_seats)
+VALUES ('49d13e51-2277-4911-929f-c9c067e2e8b4', 'b433da18-ba5a-4b86-92af-ba11be6314e7', 'EXHIBITION_TEST_1', 0, 100);
+
+INSERT INTO exhibitions(id, museum_id, exhibition_name, total_seats, booked_seats)
+VALUES ('b2cb1474-24ff-41eb-a8d7-963f32f6822d', 'b433da18-ba5a-4b86-92af-ba11be6314e7', 'EXHIBITION_TEST_2', 0, 100);
+

--- a/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/init_postgresql.sql
+++ b/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/init_postgresql.sql
@@ -8,6 +8,19 @@ CREATE TABLE museums(
 
 );
 
+
+CREATE TABLE exhibitions(
+   ID UUID  NOT NULL,
+   museum_id UUID NOT NULL,
+   exhibition_name TEXT NOT NULL,
+   total_seats INT NOT NULL,
+   booked_seats INT NOT NULL,
+   UNIQUE (exhibition_name),
+   PRIMARY KEY (ID)
+
+);
+
+
 INSERT INTO museums (id, museum_name, number_of_occupied_rooms, number_of_rooms)
 VALUES ( 'b433da18-ba5a-4b86-92af-ba11be6314e7' , 'test1', 0, 10);
 

--- a/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/persistence.xml
+++ b/com.unifi.attws.exam.museum-app/src/test/resources/META-INF/persistence.xml
@@ -7,7 +7,8 @@
 
 	<persistence-unit name="postgres">
 		<class>com.unifi.attws.exam.model.Museum</class>
-
+		<class>com.unifi.attws.exam.model.Exhibition</class>
+		
 		<properties>
 			<property name="javax.persistence.jdbc.driver"
 				value="org.testcontainers.jdbc.ContainerDatabaseDriver" />
@@ -21,7 +22,8 @@
 	
 	<persistence-unit name="postgres.not-empty.database">
 		<class>com.unifi.attws.exam.model.Museum</class>
-
+		<class>com.unifi.attws.exam.model.Exhibition</class>
+		
 		<properties>
 			<property name="javax.persistence.jdbc.driver"
 				value="org.testcontainers.jdbc.ContainerDatabaseDriver" />
@@ -29,6 +31,7 @@
 				value="jdbc:tc:postgresql:9.6.8:///databasename?TC_INITSCRIPT=file:src/test/resources/META-INF/init_postgresql.sql" />
 			<property name="hibernate.dialect"
 				value="org.hibernate.dialect.PostgreSQLDialect" />
+				<!-- This line is commented since I want to use a non empty db, which is created executing an sql script -->
 <!-- 			<property name="hibernate.hbm2ddl.auto" value="create" /> -->
 		</properties>
 	</persistence-unit>
@@ -36,16 +39,16 @@
 
 <!-- 	<persistence-unit name="postgres"> -->
 <!-- 		<class>com.unifi.attws.exam.model.Museum</class> -->
-
+<!-- 		<class>com.unifi.attws.exam.model.Exhibition</class> -->
+		
 <!-- 		<properties> -->
 <!-- 			<property name="javax.persistence.jdbc.driver" -->
 <!-- 				value="org.postgresql.Driver" /> -->
 <!-- 			<property name="javax.persistence.jdbc.url" -->
 <!-- 				value="jdbc:postgresql://localhost:5432/ATTWS_DB" /> -->
 <!-- 			<property name="javax.persistence.jdbc.user" value="attws" /> -->
-<!-- 			<property name="javax.persistence.jdbc.password" -->
-<!-- 				value="attws" /> -->
-<!-- 			<property name="hibernate.hbm2ddl.auto" value="create" /> -->
+<!-- 			<property name="javax.persistence.jdbc.password" value="attws" /> -->
+<!-- 			<property name="hibernate.hbm2ddl.auto" value="create-drop" /> -->
 <!-- 			<property name="hibernate.dialect" -->
 <!-- 				value="org.hibernate.dialect.PostgreSQLDialect" /> -->
 <!-- 		</properties> -->


### PR DESCRIPTION
This PR has been opened in order to merge the new Exhibition Entity with the develop branch context; the main goal is to create two consistent repositories (one for both Museum and Exhibition entities) and correctly handle theis relationship (one Museum has many Exhibitions) without using JPA and Hibernate specific annotations: this choice guarantees more control over DB operations and transaction management.